### PR TITLE
feat: implement authentication flow (signup, login, logout)

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,10 +1,75 @@
-import { Text, View } from 'react-native';
+import { Link } from 'expo-router';
+import { useState } from 'react';
+import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native';
+
+import { useAuth } from '@/lib/auth';
 
 export default function LoginScreen() {
+  const { signIn } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSignIn() {
+    if (!email || !password) {
+      setError('Please enter your email and password.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const { error } = await signIn(email.trim(), password);
+    setLoading(false);
+    if (error) setError(error);
+  }
+
   return (
-    <View className="flex-1 items-center justify-center bg-background px-6">
-      <Text className="text-3xl font-bold text-text-primary mb-2">Welcome back</Text>
-      <Text className="text-base text-text-secondary">Sign in to FamilyMatch</Text>
+    <View className="flex-1 justify-center bg-background px-6">
+      <Text className="text-3xl font-bold text-text-primary mb-1">Welcome back</Text>
+      <Text className="text-base text-text-secondary mb-8">Sign in to FamilyMatch</Text>
+
+      <Text className="text-sm font-medium text-text-primary mb-1">Email</Text>
+      <TextInput
+        className="bg-surface border border-border rounded-xl px-4 py-3 text-text-primary mb-4"
+        placeholder="you@example.com"
+        placeholderTextColor="#9CA3AF"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+
+      <Text className="text-sm font-medium text-text-primary mb-1">Password</Text>
+      <TextInput
+        className="bg-surface border border-border rounded-xl px-4 py-3 text-text-primary mb-4"
+        placeholder="••••••••"
+        placeholderTextColor="#9CA3AF"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+
+      {error && (
+        <Text className="text-error text-sm mb-4">{error}</Text>
+      )}
+
+      <Pressable
+        className="bg-primary rounded-xl py-4 items-center mb-4"
+        onPress={handleSignIn}
+        disabled={loading}
+      >
+        {loading
+          ? <ActivityIndicator color="#fff" />
+          : <Text className="text-white font-semibold text-base">Sign in</Text>
+        }
+      </Pressable>
+
+      <View className="flex-row justify-center">
+        <Text className="text-text-secondary">Don't have an account? </Text>
+        <Link href="/(auth)/signup">
+          <Text className="text-primary font-semibold">Sign up</Text>
+        </Link>
+      </View>
     </View>
   );
 }

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -1,10 +1,90 @@
-import { Text, View } from 'react-native';
+import { Link } from 'expo-router';
+import { useState } from 'react';
+import { ActivityIndicator, Pressable, Text, TextInput, View } from 'react-native';
+
+import { useAuth } from '@/lib/auth';
 
 export default function SignupScreen() {
+  const { signUp } = useAuth();
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSignUp() {
+    if (!fullName || !email || !password) {
+      setError('Please fill in all fields.');
+      return;
+    }
+    if (password.length < 6) {
+      setError('Password must be at least 6 characters.');
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    const { error } = await signUp(email.trim(), password, fullName.trim());
+    setLoading(false);
+    if (error) setError(error);
+  }
+
   return (
-    <View className="flex-1 items-center justify-center bg-background px-6">
-      <Text className="text-3xl font-bold text-text-primary mb-2">Create account</Text>
-      <Text className="text-base text-text-secondary">Join FamilyMatch</Text>
+    <View className="flex-1 justify-center bg-background px-6">
+      <Text className="text-3xl font-bold text-text-primary mb-1">Create account</Text>
+      <Text className="text-base text-text-secondary mb-8">Join FamilyMatch</Text>
+
+      <Text className="text-sm font-medium text-text-primary mb-1">Full name</Text>
+      <TextInput
+        className="bg-surface border border-border rounded-xl px-4 py-3 text-text-primary mb-4"
+        placeholder="Jane Smith"
+        placeholderTextColor="#9CA3AF"
+        autoCapitalize="words"
+        value={fullName}
+        onChangeText={setFullName}
+      />
+
+      <Text className="text-sm font-medium text-text-primary mb-1">Email</Text>
+      <TextInput
+        className="bg-surface border border-border rounded-xl px-4 py-3 text-text-primary mb-4"
+        placeholder="you@example.com"
+        placeholderTextColor="#9CA3AF"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+
+      <Text className="text-sm font-medium text-text-primary mb-1">Password</Text>
+      <TextInput
+        className="bg-surface border border-border rounded-xl px-4 py-3 text-text-primary mb-4"
+        placeholder="Min. 6 characters"
+        placeholderTextColor="#9CA3AF"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+
+      {error && (
+        <Text className="text-error text-sm mb-4">{error}</Text>
+      )}
+
+      <Pressable
+        className="bg-primary rounded-xl py-4 items-center mb-4"
+        onPress={handleSignUp}
+        disabled={loading}
+      >
+        {loading
+          ? <ActivityIndicator color="#fff" />
+          : <Text className="text-white font-semibold text-base">Create account</Text>
+        }
+      </Pressable>
+
+      <View className="flex-row justify-center">
+        <Text className="text-text-secondary">Already have an account? </Text>
+        <Link href="/(auth)/login">
+          <Text className="text-primary font-semibold">Sign in</Text>
+        </Link>
+      </View>
     </View>
   );
 }

--- a/app/(tabs)/profile/index.tsx
+++ b/app/(tabs)/profile/index.tsx
@@ -1,12 +1,25 @@
-import { Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
+
+import { useAuth } from '@/lib/auth';
 
 export default function ProfileScreen() {
+  const { user, signOut } = useAuth();
+
   return (
-    <View className="flex-1 items-center justify-center bg-background">
-      <View className="bg-surface rounded-2xl p-6 shadow-sm items-center">
+    <View className="flex-1 items-center justify-center bg-background px-6">
+      <View className="bg-surface rounded-2xl p-6 shadow-sm items-center w-full mb-6">
         <Text className="text-2xl font-bold text-text-primary">Profile</Text>
-        <Text className="text-base text-text-secondary mt-2">Your family profile</Text>
+        {user && (
+          <Text className="text-base text-text-secondary mt-2">{user.email}</Text>
+        )}
       </View>
+
+      <Pressable
+        className="bg-error rounded-xl py-4 items-center w-full"
+        onPress={signOut}
+      >
+        <Text className="text-white font-semibold text-base">Log out</Text>
+      </Pressable>
     </View>
   );
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -2,23 +2,20 @@ import '../global.css';
 
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { useFonts } from 'expo-font';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
 
 import { useColorScheme } from '@/components/useColorScheme';
+import { AuthProvider, useAuth } from '@/lib/auth';
 
-export {
-  // Catch any errors thrown by the Layout component.
-  ErrorBoundary,
-} from 'expo-router';
+export { ErrorBoundary } from 'expo-router';
 
 export const unstable_settings = {
   initialRouteName: '(tabs)',
 };
 
-// Prevent the splash screen from auto-hiding before asset loading is complete.
 SplashScreen.preventAutoHideAsync();
 
 export default function RootLayout() {
@@ -26,26 +23,35 @@ export default function RootLayout() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
 
-  // Expo Router uses Error Boundaries to catch errors in the navigation tree.
   useEffect(() => {
     if (error) throw error;
   }, [error]);
 
   useEffect(() => {
-    if (loaded) {
-      SplashScreen.hideAsync();
-    }
+    if (loaded) SplashScreen.hideAsync();
   }, [loaded]);
 
-  if (!loaded) {
-    return null;
-  }
+  if (!loaded) return null;
 
-  return <RootLayoutNav />;
+  return (
+    <AuthProvider>
+      <RootLayoutNav />
+    </AuthProvider>
+  );
 }
 
 function RootLayoutNav() {
   const colorScheme = useColorScheme();
+  const { session, loading } = useAuth();
+
+  useEffect(() => {
+    if (loading) return;
+    if (session) {
+      router.replace('/(tabs)/discover');
+    } else {
+      router.replace('/(auth)/login');
+    }
+  }, [session, loading]);
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -1,0 +1,63 @@
+import { Session, User } from '@supabase/supabase-js';
+import { createContext, useContext, useEffect, useState } from 'react';
+
+import { supabase } from './supabase';
+
+interface AuthContextValue {
+  session: Session | null;
+  user: User | null;
+  loading: boolean;
+  signUp: (email: string, password: string, fullName: string) => Promise<{ error: string | null }>;
+  signIn: (email: string, password: string) => Promise<{ error: string | null }>;
+  signOut: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setSession(session);
+      setLoading(false);
+    });
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session);
+    });
+
+    return () => subscription.unsubscribe();
+  }, []);
+
+  async function signUp(email: string, password: string, fullName: string) {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { full_name: fullName } },
+    });
+    return { error: error ? error.message : null };
+  }
+
+  async function signIn(email: string, password: string) {
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    return { error: error ? error.message : null };
+  }
+
+  async function signOut() {
+    await supabase.auth.signOut();
+  }
+
+  return (
+    <AuthContext.Provider value={{ session, user: session?.user ?? null, loading, signUp, signIn, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider');
+  return ctx;
+}

--- a/supabase/migrations/20260323110644_create_profile_trigger.sql
+++ b/supabase/migrations/20260323110644_create_profile_trigger.sql
@@ -1,0 +1,19 @@
+-- Automatically create a profiles row when a new user signs up.
+-- Extracts full_name from raw_user_meta_data set during signUp().
+CREATE OR REPLACE FUNCTION handle_new_user()
+RETURNS trigger LANGUAGE plpgsql SECURITY DEFINER AS $$
+BEGIN
+  INSERT INTO public.profiles (id, email, full_name)
+  VALUES (
+    NEW.id,
+    NEW.email,
+    COALESCE(NEW.raw_user_meta_data->>'full_name', '')
+  )
+  ON CONFLICT (id) DO NOTHING;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION handle_new_user();

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,23 @@
+-- Seed a test user for local development.
+-- Email: test@familymatch.dev  Password: password123
+INSERT INTO auth.users (
+  id,
+  email,
+  encrypted_password,
+  email_confirmed_at,
+  created_at,
+  updated_at,
+  raw_user_meta_data,
+  aud,
+  role
+) VALUES (
+  '00000000-0000-0000-0000-000000000001',
+  'test@familymatch.dev',
+  crypt('password123', gen_salt('bf')),
+  now(),
+  now(),
+  now(),
+  '{"full_name": "Test User"}'::jsonb,
+  'authenticated',
+  'authenticated'
+) ON CONFLICT (id) DO NOTHING;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".expo/types/**/*.ts",
-    "expo-env.d.ts"
+    "expo-env.d.ts",
+    "nativewind-env.d.ts"
   ]
 }


### PR DESCRIPTION
## Summary
- `AuthProvider` context with session management via `onAuthStateChange`
- Root layout auth guard — redirects to login or discover based on session
- Login and signup screens with form validation and error messages
- Profile tab logout button
- `handle_new_user` Postgres trigger auto-creates profile row on signup
- Seed user for local testing: `test@familymatch.dev` / `password123`

## Test plan
- [ ] `npx expo start --clear` — app opens on login screen
- [ ] Sign in with `test@familymatch.dev` / `password123` → lands on Discover
- [ ] Log out from Profile tab → redirected back to login
- [ ] Sign up with a new email → profile row created automatically

Closes #6
Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)